### PR TITLE
Add pinned dependencies to workflow

### DIFF
--- a/.github/workflows/create-tag.yaml
+++ b/.github/workflows/create-tag.yaml
@@ -4,21 +4,29 @@ on:
     branches: 
       - main
   
+permissions:  # added using https://github.com/step-security/secure-repo
+  contents: read
+
 jobs:
   Build-Code:
     permissions:
       contents: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - name: Harden Runner
+      uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+      with:
+        egress-policy: audit
+
+    - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       with:
         fetch-depth: 0
     - name: Install GitVersion
-      uses: gittools/actions/gitversion/setup@v0.11.0
+      uses: gittools/actions/gitversion/setup@629337911bdf17f9af8800f53645e55e740dce76 # v0.11.0
       with:
         versionSpec: '5.x'
     - name: Determine Version
-      uses: gittools/actions/gitversion/execute@v0.11.0
+      uses: gittools/actions/gitversion/execute@629337911bdf17f9af8800f53645e55e740dce76 # v0.11.0
       with:
         useConfigFile: true
     - name: Create git tag


### PR DESCRIPTION
Following OSSF scorecard guidance, added pinning of dependencies: https://github.com/ossf/scorecard/blob/ea7e27ed41b76ab879c862fa0ca4cc9c61764ee4/docs/checks.md#pinned-dependencies
